### PR TITLE
Fix installation failure due to missing 3rd party libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
-
 from setuptools import setup
-from tcping import __version__
+
+
+with open("tcping.py") as fp:
+    for line in fp:
+        if line.startswith("__version__"):
+            __version__ = line.split("=").strip(" \"'\r\n")
+            break
+    else:
+        from tcping import __version__
 
 
 def read_long_description():


### PR DESCRIPTION
Because I haven't installed click before, I got following error on installation.

```
C:\Users\sakurai>pip install tcping
Collecting tcping
  Using cached tcping-0.1.0rc1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\sakurai\AppData\Local\Temp\pip-build-sw3p6lo9\tcping\setup.py", line 7, in <module>
        from tcping import __version__
      File "C:\Users\sakurai\AppData\Local\Temp\pip-build-sw3p6lo9\tcping\tcping.py", line 10, in <module>
        import click
    ModuleNotFoundError: No module named 'click'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\sakurai\AppData\Local\Temp\pip-build-sw3p6lo9\tcping\
```

Actually, `click` is already added to install_requires, however, it doesn't work well because of importing tcping which depends on the `click` and other 3rd party packages. My modification works around the issue by parsing `__version__` manually from `tcping.py`.