### PR TITLE
Fix problem not to install tcping module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def read_long_description():
     except(IOError, ImportError, RuntimeError):
         return ""
 
+
 setup(
     name='tcping',
     version=__version__,
@@ -24,6 +25,7 @@ setup(
     description='command line for tcp ping',
     license='MIT',
     keywords='python tcp ping',
+    py_modules=['tcping'],
     scripts=['tcping.py'],
     install_requires=['six', 'click', 'prettytable'],
     entry_points={


### PR DESCRIPTION
On Windows, after installation, installed script doesn't work well with following error.

```
Traceback (most recent call last):
  File "c:\python36\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python36\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python36\Scripts\tcping.exe\__main__.py", line 5, in <module>
ModuleNotFoundError: No module named 'tcping'
```

But this issue can be resolved easily once you install tcping.py not only as script but also as module.