### PR TITLE
Add return code for tcping.

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -59,6 +59,21 @@ Connected to api.github.com[:80]: seq=3 time=258.53 ms
 | api.github.com |  80  |     3     |   0    |   100.00%    | 237.72ms | 258.53ms | 244.68ms |
 +----------------+------+-----------+--------+--------------+----------+----------+----------+
 ```
+
+返回的运行状态码可以用于实时的批量测试，例如判断服务器连通情况。0和1分别参照ICMP PING工具设定，0表示PING通。下面是一个简单的获取返回码测试。
+
+```python
+import subprocess as sp
+
+# Print the return code (status=0 mean ping success)
+status = sp.call(['tcping', '-c', '1', '-t', '1', 'github.com'], stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+print(status)
+
+# OR print the full message
+sp.run(['tcping', '-c', '1', '-t', '1', 'github.com'], stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+print(status)
+```
+
 ## END 
 
 其实写这个主要是为了测试搭建翻墙 VPS 的 tcp 延迟。。。

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ Connected to api.github.com[:80]: seq=3 time=258.53 ms
 | api.github.com |  80  |     3     |   0    |   100.00%    | 237.72ms | 258.53ms | 244.68ms |
 +----------------+------+-----------+--------+--------------+----------+----------+----------+
 ```
+
+The return code can be catch by some real-time test tools. Following is an example:
+
+```python
+import subprocess as sp
+
+# Print the return code (status=0 mean ping success)
+status = sp.call(['tcping', '-c', '1', '-t', '1', 'github.com'], stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+print(status)
+
+# OR print the full message
+sp.run(['tcping', '-c', '1', '-t', '1', 'github.com'], stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+print(status)
+```
+
 ## END 
 
 Huh, I just want to check my VPS's network status.

--- a/tcping.py
+++ b/tcping.py
@@ -8,6 +8,7 @@
 import socket
 import time
 import click
+import sys
 
 from collections import namedtuple
 from functools import partial
@@ -161,6 +162,10 @@ class Ping(object):
     def result(self):
         return self.print_
 
+    @property
+    def status(self):
+        return self._successed == 0
+
     def ping(self, count=10):
         for n in range(1, count + 1):
             s = self._create_socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -210,6 +215,7 @@ def cli(host, port, count, timeout, report):
         iprint(ping.result.table)
     else:
         iprint(ping.result.raw)
+    sys.exit(ping.status)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Refer to ICMP Ping tool, return 0 if ping success else 1.
This return code can be used for real-time net check calling.
The program runs with the return code ending, but it does not appear in the output.